### PR TITLE
fix: neoforge can't create transforms file when gradle sync

### DIFF
--- a/sinoseries-meta/sinoseries-meta-neoforge/build.gradle
+++ b/sinoseries-meta/sinoseries-meta-neoforge/build.gradle
@@ -58,12 +58,17 @@ classes {
 
 processResources {
     var projectTransformsFile = new File(projectDir, '/.gradle/architectury/.transforms')
+    Files.createParentDirs(projectTransformsFile)
     java.nio.file.Files.deleteIfExists(projectTransformsFile.toPath())
     java.nio.file.Files.createFile(projectTransformsFile.toPath())
 
     subMod.each { Project mod ->
         helpers.getSubNeoForgeMod(mod).each { Project neoForgeMod ->
             var subModTransformsFile = new File(neoForgeMod.projectDir, '/.gradle/architectury/.transforms')
+            if (!subModTransformsFile.isFile()) {
+                Files.createParentDirs(subModTransformsFile)
+                java.nio.file.Files.createFile(subModTransformsFile.toPath())
+            }
             var lines = java.nio.file.Files.readString(subModTransformsFile.toPath())
             Files.asCharSink(projectTransformsFile, StandardCharsets.UTF_8, FileWriteMode.APPEND)
                     .write(lines)


### PR DESCRIPTION
fix: neoforge 部分，第一次加载时 .transforms 文件无法正常创建和读取